### PR TITLE
Add support for kernel 5.0

### DIFF
--- a/hal/hal_dm.c
+++ b/hal/hal_dm.c
@@ -79,7 +79,9 @@ void rtw_hal_update_iqk_fw_offload_cap(_adapter *adapter)
 	RTW_INFO("IQK FW offload:%s\n", hal->RegIQKFWOffload ? "enable" : "disable");
 
 	if (rtw_mi_check_status(adapter, MI_LINKED)) {
+#ifdef CONFIG_LPS
 		LPS_Leave(adapter, "SWITCH_IQK_OFFLOAD");
+#endif
 		halrf_iqk_trigger(p_dm_odm, _FALSE);
 	}
 }

--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -690,8 +690,13 @@ static int rtw_cfg80211_sync_iftype(_adapter *adapter)
 static u64 rtw_get_systime_us(void)
 {
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 39))
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 20, 0))
+	struct timespec64 ts;
+	ktime_get_boottime_ts64(&ts);
+#else
 	struct timespec ts;
 	get_monotonic_boottime(&ts);
+#endif
 	return ((u64)ts.tv_sec * 1000000) + ts.tv_nsec / 1000;
 #else
 	struct timeval tv;

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1459,9 +1459,15 @@ unsigned int rtw_classify8021d(struct sk_buff *skb)
 
 static u16 rtw_select_queue(struct net_device *dev, struct sk_buff *skb
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 13, 0)
-	, void *accel_priv
+	#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 19, 0)
+		, struct net_device *sb_dev
+	#else
+		, void *accel_priv
+	#endif
 	#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
-	, select_queue_fallback_t fallback
+		#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 2, 0)
+			, select_queue_fallback_t fallback
+		#endif
 	#endif
 #endif
 )

--- a/os_dep/linux/rtw_android.c
+++ b/os_dep/linux/rtw_android.c
@@ -664,7 +664,11 @@ int rtw_android_priv_cmd(struct net_device *net, struct ifreq *ifr, int cmd)
 		goto exit;
 	}
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 0, 0))
+	if (!access_ok(priv_cmd.buf, priv_cmd.total_len)) {
+#else
 	if (!access_ok(VERIFY_READ, priv_cmd.buf, priv_cmd.total_len)) {
+#endif
 		RTW_INFO("%s: failed to access memory\n", __FUNCTION__);
 		ret = -EFAULT;
 		goto exit;

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -147,6 +147,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== Customer ID ===*/
 	/****** 8188EUS ********/
 	{USB_DEVICE(0x07B8, 0x8179), .driver_info = RTL8188E}, /* Abocom - Abocom */
+	{USB_DEVICE(0x2357, 0x010c), .driver_info = RTL8188E}, /* TP-Link - TL-WN722N v2 */
 #endif
 
 #ifdef CONFIG_RTL8812A


### PR DESCRIPTION
Hi,
I tried to modify this driver to get it working on kernel 5.0. I am not sure about changes in hal_dm.c. Anyway, I was able to build this module successfully on kernel 5.0.18 and I could use TL-WN722N v2. 
@kimocoder

P.S. I tried using this driver with OpenWRT, however I only got stack traces :(