### PR TITLE
Support POWERPC64LE platform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ CONFIG_PLATFORM_AML_S905 = n
 CONFIG_PLATFORM_ZTE_ZX296716 = n
 CONFIG_PLATFORM_ARM_ODROIDC2 = n
 CONFIG_PLATFORM_PPC = n
+CONFIG_PLATFORM_PPC64LE = n
 ###############################################################
 
 CONFIG_DRVEXT_MODULE = n
@@ -1031,8 +1032,7 @@ EXTRA_CFLAGS += -DDM_ODM_SUPPORT_TYPE=0x04
 ifeq ($(CONFIG_PLATFORM_I386_PC), y)
 EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
 EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
-SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
-ARCH ?= $(SUBARCH)
+SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc64le/powerpc/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
@@ -1077,6 +1077,17 @@ endif
 ifeq ($(CONFIG_PLATFORM_PPC), y)
 EXTRA_CFLAGS += -DCONFIG_BIG_ENDIAN
 SUBARCH := $(shell uname -m | sed -e s/ppc/powerpc/)
+ARCH ?= $(SUBARCH)
+CROSS_COMPILE ?=
+KVER ?= $(shell uname -r)
+KSRC := /lib/modules/$(KVER)/build
+MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
+INSTALL_PREFIX :=
+endif
+
+ifeq ($(CONFIG_PLATFORM_PPC64LE), y)
+EXTRA_CFLAGS += -DCONFIG_LITTLE_ENDIAN
+SUBARCH := $(shell uname -m | sed -e s/ppc64le/powerpc/)
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
 KVER ?= $(shell uname -r)


### PR DESCRIPTION
The module could not be compiled because the `SUBARCH` is not picked up correctly.

Tested on Raptor Blackbird workstation running Fedora 32 PPC64LE.