### PR TITLE
Adding support for Edimax EW-7811UN v2

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -159,7 +159,8 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2001, 0x3310), .driver_info = RTL8188E}, /* Dlink DWA-123 REV D1 */ 
 	{USB_DEVICE(0x2001, 0x3311), .driver_info = RTL8188E}, /* DLink GO-USB-N150 REV B1 */ 
 	{USB_DEVICE(0x2001, 0x331B), .driver_info = RTL8188E}, /* DLink DWA-121 REV B1 */ 
-	{USB_DEVICE(0x056E, 0x4008), .driver_info = RTL8188E}, /* Elecom WDC-150SU2M */ 	
+	{USB_DEVICE(0x056E, 0x4008), .driver_info = RTL8188E}, /* Elecom WDC-150SU2M */ 
+	{USB_DEVICE(0x7392, 0xB811), .driver_info = RTL8188E}, /* Edimax EW-7811UN v2 */
 #endif
 
 #ifdef CONFIG_RTL8812A


### PR DESCRIPTION
Device:
```console
Bus 001 Device 007: ID 7392:b811 Edimax Technology Co., Ltd Edimax N150 Adapter
```

```console
Linux kali 5.14.0-kali4-amd64 #1 SMP Debian 5.14.16-1kali1 (2021-11-05) x86_64 GNU/Linux
```
Monitor mode works, aireplay-ng injection works

```console
Linux debian11 5.10.0-9-amd64 #1 SMP Debian 5.10.70-1 (2021-09-30) x86_64 GNU/Linux
```
Monitor mode works, aireplay-ng injection works