### PR TITLE
Compile with kernel v5.15

### DIFF
--- a/core/rtw_br_ext.c
+++ b/core/rtw_br_ext.c
@@ -15,9 +15,12 @@
 #define _RTW_BR_EXT_C_
 
 #ifdef __KERNEL__
+    #include <linux/version.h>
 	#include <linux/if_arp.h>
 	#include <net/ip.h>
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 	#include <net/ipx.h>
+#endif
 	#include <linux/atalk.h>
 	#include <linux/udp.h>
 	#include <linux/if_pppox.h>
@@ -948,6 +951,7 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 			}
 		}
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
 		/*   IPX  */
 		if (ipx != NULL) {
 			switch (method) {
@@ -1016,8 +1020,12 @@ int nat25_db_handle(_adapter *priv, struct sk_buff *skb, int method)
 			}
 		}
 
+
 		/*   AARP  */
 		else if (ea != NULL) {
+#else
+		if (ea != NULL) {
+#endif
 			/* Sanity check fields. */
 			if (ea->hw_len != ETH_ALEN || ea->pa_len != AARP_PA_ALEN) {
 				DEBUG_WARN("NAT25: Appletalk AARP Sanity check fail!\n");

--- a/core/rtw_mlme_ext.c
+++ b/core/rtw_mlme_ext.c
@@ -1831,11 +1831,13 @@ void mgt_dispatcher(_adapter *padapter, union recv_frame *precv_frame)
 			ptable->func = &OnAuth;
 		else
 			ptable->func = &OnAuthClient;
+		_mgt_dispatcher(padapter, ptable, precv_frame);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 4, 0)
 	__attribute__ ((fallthrough));
 #else
 			__attribute__ ((__fallthrough__));
 #endif
+        break;
 	case WIFI_ASSOCREQ:
 	case WIFI_REASSOCREQ:
 		_mgt_dispatcher(padapter, ptable, precv_frame);


### PR DESCRIPTION
```
$ sudo uname -a
Linux andypc 5.16.0-arch1-1 #1 SMP PREEMPT Mon, 10 Jan 2022 20:11:47 +0000 x86_64 GNU/Linux

$ make
<...>
/work/projects/rtl8188eus/core/rtw_br_ext.c:20:18: fatal error: net/ipx.h: No such file or directory
   20 |         #include <net/ipx.h>
      |                  ^~~~~~~~~~~
compilation terminated.
make[2]: *** [scripts/Makefile.build:287: /work/projects/rtl8188eus/core/rtw_br_ext.o] Error 1
make[1]: *** [Makefile:1846: /work/projects/rtl8188eus] Error 2
make[1]: Leaving directory '/usr/lib/modules/5.16.0-arch1-1/build'
make: *** [Makefile:2062: modules] Error 2
```

The ipx network layer has been [removed](https://lore.kernel.org/netdev/1710508.VLH7GnMWUR@x2/T/) from kernel v5.15.
