### PR TITLE
build support for kernel 5.18 and above

### DIFF
--- a/include/ieee80211.h
+++ b/include/ieee80211.h
@@ -1529,6 +1529,7 @@ enum ieee80211_state {
 	(((Addr[2]) & 0xff) == 0xff) && (((Addr[3]) & 0xff) == 0xff) && (((Addr[4]) & 0xff) == 0xff) && \
 				     (((Addr[5]) & 0xff) == 0xff))
 #else
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(5, 18, 00))
 extern __inline int is_multicast_mac_addr(const u8 *addr)
 {
 	return (addr[0] != 0xff) && (0x01 & addr[0]);
@@ -1545,6 +1546,24 @@ extern __inline int is_zero_mac_addr(const u8 *addr)
 	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
 		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
 }
+#else 
+static __inline int is_multicast_mac_addr(const u8 *addr)
+{
+	return (addr[0] != 0xff) && (0x01 & addr[0]);
+}
+
+static __inline int is_broadcast_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0xff) && (addr[1] == 0xff) && (addr[2] == 0xff) &&   \
+		(addr[3] == 0xff) && (addr[4] == 0xff) && (addr[5] == 0xff));
+}
+
+static __inline int is_zero_mac_addr(const u8 *addr)
+{
+	return ((addr[0] == 0x00) && (addr[1] == 0x00) && (addr[2] == 0x00) &&   \
+		(addr[3] == 0x00) && (addr[4] == 0x00) && (addr[5] == 0x00));
+}
+#endif /* LINUX_VERSION_CODE */
 #endif /* PLATFORM_FREEBSD */
 
 #define CFG_IEEE80211_RESERVE_FCS (1<<0)


### PR DESCRIPTION
Hi,

Found out that on kernel 5.18 and above the bump of C standard to C99 changed extern inline comportement and to keep the same behaviour I had to replace extern inline to static inline. 
This is a change to ieee80211.h that should handle the difference in behavior without much issue 