### PR TITLE
build support for kernel 5.19.2+ and 6.0

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.c
+++ b/os_dep/linux/ioctl_cfg80211.c
@@ -417,7 +417,11 @@ u8 rtw_cfg80211_ch_switch_notify(_adapter *adapter, u8 ch, u8 bw, u8 offset, u8 
 	if (ret != _SUCCESS)
 		goto exit;
 
-	cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+        cfg80211_ch_switch_notify(adapter->pnetdev, &chdef, 0);
+#else
+        cfg80211_ch_switch_notify(adapter->pnetdev, &chdef);
+#endif
 
 #else
 	int freq = rtw_ch2freq(ch);
@@ -1099,7 +1103,11 @@ check_bss:
 		#endif
 
 		#if (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 12, 0) || defined(RHEL79))
-		roam_info.bssid = cur_network->network.MacAddress;
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+                roam_info.links[0].bssid = cur_network->network.MacAddress;
+#else
+                roam_info.bssid = cur_network->network.MacAddress;
+#endif
 		roam_info.req_ie = pmlmepriv->assoc_req + sizeof(struct rtw_ieee80211_hdr_3addr) + 2;
 		roam_info.req_ie_len = pmlmepriv->assoc_req_len - sizeof(struct rtw_ieee80211_hdr_3addr) - 2;
 		roam_info.resp_ie = pmlmepriv->assoc_rsp + sizeof(struct rtw_ieee80211_hdr_3addr) + 6;
@@ -4876,7 +4884,11 @@ static int cfg80211_rtw_change_beacon(struct wiphy *wiphy, struct net_device *nd
 	return ret;
 }
 
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev, unsigned int link_id)
+#else
 static int cfg80211_rtw_stop_ap(struct wiphy *wiphy, struct net_device *ndev)
+#endif
 {
 	_adapter *adapter = (_adapter *)rtw_netdev_priv(ndev);
 
@@ -9634,7 +9646,13 @@ void rtw_wdev_unregister(struct wireless_dev *wdev)
 	rtw_cfg80211_indicate_scan_done(adapter, _TRUE);
 
 	#if (LINUX_VERSION_CODE >= KERNEL_VERSION(3, 11, 0)) || defined(COMPAT_KERNEL_RELEASE)
-	if (wdev->current_bss) {
+        #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 0, 0))
+        if (wdev->links[0].client.current_bss) {
+        #elif (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 19, 2))
+        if (wdev->connected) {
+        #else
+        if (wdev->current_bss) {
+        #endif
 		RTW_INFO(FUNC_ADPT_FMT" clear current_bss by cfg80211_disconnected\n", FUNC_ADPT_ARG(adapter));
 		rtw_cfg80211_indicate_disconnect(adapter, 0, 1);
 	}


### PR DESCRIPTION
Apply to compile 8188eu.ko for 5.19.2+ and 6.0. 
Code is partly taken from https://github.com/aircrack-ng/rtl8812au/blob/v5.6.4.2/os_dep/linux/ioctl_cfg80211.c