### PR TITLE
fix: adapt to old kernels (v3.18)

### DIFF
--- a/os_dep/linux/ioctl_cfg80211.h
+++ b/os_dep/linux/ioctl_cfg80211.h
@@ -363,7 +363,7 @@ void rtw_cfg80211_deinit_rfkill(struct wiphy *wiphy);
 #define rtw_cfg80211_connect_result(wdev, bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp) cfg80211_connect_result(wdev_to_ndev(wdev), bssid, req_ie, req_ie_len, resp_ie, resp_ie_len, status, gfp)
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 2, 0) && !defined(RHEL79))
-#define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, gfp)
+#define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, ie_len, gfp)
 #else
 #define rtw_cfg80211_disconnected(wdev, reason, ie, ie_len, locally_generated, gfp) cfg80211_disconnected(wdev_to_ndev(wdev), reason, ie, ie_len, locally_generated, gfp)
 #endif

--- a/os_dep/linux/rtw_cfgvendor.c
+++ b/os_dep/linux/rtw_cfgvendor.c
@@ -145,7 +145,7 @@ struct sk_buff *rtw_cfg80211_vendor_event_alloc(
 	struct sk_buff *skb;
 
 #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0))
-	skb = cfg80211_vendor_event_alloc(wiphy, len, event_id, gfp);
+	skb = cfg80211_vendor_event_alloc(wiphy, NULL, len, event_id, gfp);
 #else
 	skb = cfg80211_vendor_event_alloc(wiphy, wdev, len, event_id, gfp);
 #endif


### PR DESCRIPTION
Fixing compile errors on old kernels (v3.18) caused by arguments misisng.