### PR TITLE
Add ZTopInc USB Product and Vendor ID

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -161,6 +161,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE(0x2001, 0x331B), .driver_info = RTL8188E}, /* DLink DWA-121 REV B1 */ 
 	{USB_DEVICE(0x056E, 0x4008), .driver_info = RTL8188E}, /* Elecom WDC-150SU2M */ 
 	{USB_DEVICE(0x7392, 0xB811), .driver_info = RTL8188E}, /* Edimax EW-7811UN v2 */
+	{USB_DEVICE(0x350B, 0x9101), .driver_info = RTL8188E}, /* ZTopInc 802.11n NIC */
 #endif
 
 #ifdef CONFIG_RTL8812A


### PR DESCRIPTION
Added Product and Vendor ID for `ZTopInc 802.11n NIC` for support