### PR TITLE
Enable building with different kernel versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1041,8 +1041,10 @@ EXTRA_CFLAGS += -DCONFIG_IOCTL_CFG80211 -DRTW_USE_CFG80211_STA_EVENT
 SUBARCH := $(shell uname -m | sed -e "s/i.86/i386/; s/ppc64le/powerpc/; s/ppc/powerpc/; s/armv.l/arm/; s/aarch64/arm64/;")
 ARCH ?= $(SUBARCH)
 CROSS_COMPILE ?=
+ifeq ($(strip $(KSRC)),)
 KVER  := $(shell uname -r)
 KSRC := /lib/modules/$(KVER)/build
+endif
 MODDESTDIR := /lib/modules/$(KVER)/kernel/drivers/net/wireless/
 INSTALL_PREFIX :=
 STAGINGMODDIR := /lib/modules/$(KVER)/kernel/drivers/staging


### PR DESCRIPTION
current Makefile only allow build with current running kernel even if is specified a different KSRC
do not change any logic if KSRC is not specified